### PR TITLE
Feat/scrape news by category

### DIFF
--- a/news_crawler/news_crawler/spiders/news.py
+++ b/news_crawler/news_crawler/spiders/news.py
@@ -42,4 +42,4 @@ class NewsSpider(Spider):
 
         next_page_url = response.xpath('//*[contains(@class, "pager-next")]/a/@href').extract_first()
         absolute_next_page_url = response.urljoin(next_page_url)
-        yield Request(absolute_next_page_url)
+        yield Request(absolute_next_page_url, callback=self.parse_stories)

--- a/news_crawler/news_crawler/spiders/news.py
+++ b/news_crawler/news_crawler/spiders/news.py
@@ -1,19 +1,39 @@
 # -*- coding: utf-8 -*-
 from scrapy import Spider
 from scrapy.http import Request
-
+import logging
+logger = logging.getLogger('subjectslogger')
 
 class NewsSpider(Spider):
     name = 'news'
     allowed_domains = ['saharareporters.com']
-    start_urls = ['http://saharareporters.com/news']
+    start_urls = ['http://saharareporters.com']
+
+    def __init__(self, story=None):
+        self.story = story
 
     def parse(self, response):
+        # scrape by stories by category or scrape all stories except for video stories
+        if self.story:
+            story_url = response.xpath('//li[contains(@class, "menu-mlid")]/a[contains(@href, "'+ self.story +'")]/@href').extract_first()
+            if story_url != "/videos":
+                absolute_story_url = response.urljoin(story_url)
+                yield Request(absolute_story_url, callback = self.parse_stories)
+        else:
+            logger.info('Scraping all stories......... %s', response.url)
+            stories = response.xpath('//li[contains(@class, "menu-mlid")]/a/@href').extract()
+            for story in stories:
+                if story != "/videos":
+                    absolute_story_url = response.urljoin(story)
+                    yield Request(absolute_story_url, callback=self.parse_stories)
+
+
+    def parse_stories(self, response):
+        ## scrape story attributes
         stories = response.xpath('//*[@class="block-module-content"]')
         for story in stories:
             category = story.xpath('.//a[@class="block-module-content-header-heading"]/text()').extract_first()
             headline = story.xpath('.//span[@class="block-module-content-header-title"]/a/text()').extract_first()
-            comments = story.xpath('.//a[@data-disqus-identifier="node/78199"]/text()').extract_first()
             release_date = story.xpath('.//div[contains(@class, "block-module-content-footer-item-date")]/text()').extract_first()
 
             yield{"category": category,


### PR DESCRIPTION
#### What does this PR do?
Scrape all stories

#### Description of Task to be completed?
-  Scrape all stories by categories: **_news, opinion, #nigeriadecides, politics, health, sports, entertainment, lifestyle, photos, documents, and education._**

#### How should this be manually tested?
- Activate virtual environment
- Install requirements.txt
- Run _**scrapy crawl news**_ to run the spider on all subjects
- Run _**scrapy crawl news -a story ="name_of_news"**_ to run the spider on individual category
   e.g  _**scrapy crawl news -a story="politics"**_ to run spider on Political news only
- Run _**scrapy crawl news -o stories.csv**_ to scrape all stories into a CSV file 
- Run _**scrapy crawl news -o stories.xml**_ to scrape all stories into an XML file 
- Run _**scrapy crawl news -o stories.json**_ to scrape all stories into a JSON file 
- Run _**scrapy crawl news -o stories.csv -o stories.xml -o stories.json**_ to generate all files 
   at once.
- You can also combine the argument and the output file options in the crawl command
   e.g **_scrapy crawl news -a story="entertainment" -o entertainment.csv_**

#### Screenshots 
N/A